### PR TITLE
Fixed ReadJson on MailgunHttpResponse

### DIFF
--- a/src/Typesafe.Mailgun/Http/MailgunHttpResponse.cs
+++ b/src/Typesafe.Mailgun/Http/MailgunHttpResponse.cs
@@ -24,7 +24,8 @@ namespace Typesafe.Mailgun.Http
 
 		private void ReadJson()
 		{
-			if (httpResonse.ContentType != "application/json") return;
+            //Sometimes the server returns application/json; charset=utf-8
+			if (!httpResonse.ContentType.StartsWith("application/json")) return;
 
 			using (var reader = new StreamReader(httpResonse.GetResponseStream()))
 				Body = JToken.ReadFrom(new JsonTextReader(reader));


### PR DESCRIPTION
This was causing the unit tests to fail when the server specifies the encoding with the content type