### PR TITLE
Adds the ability to apply tags to your email messages

### DIFF
--- a/src/Typesafe.Mailgun.Tests/FormPartsBuilderTests.cs
+++ b/src/Typesafe.Mailgun.Tests/FormPartsBuilderTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net.Mail;
 using System.Net.Mime;
 using NUnit.Framework;
+using Typesafe.Mailgun.Extensions;
 using Typesafe.Mailgun.Http;
 
 namespace Typesafe.Mailgun.Tests
@@ -88,6 +89,15 @@ namespace Typesafe.Mailgun.Tests
 			var result = FormPartsBuilder.Build(message);
 			result.AssertContains("html", "<h1>Test Passed</h1>");
 			result.AssertDoesntContain("text");
+		}
+
+
+		[Test]
+		public void Build_TagsSpecified_AddsTagPart()
+		{
+			var message = BuildMessage(x => { x.AddTag("TagExample"); });
+			var result = FormPartsBuilder.Build(message);
+			result.AssertContains("o:tag", "TagExample");
 		}
 
 		[Test]

--- a/src/Typesafe.Mailgun/Extensions/MailMessageExtensions.cs
+++ b/src/Typesafe.Mailgun/Extensions/MailMessageExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System.Net.Mail;
+
+namespace Typesafe.Mailgun.Extensions
+{
+	/// <summary>
+	/// Extensions to the <see cref="System.Net.Mail.MailMessage"/> class
+	/// </summary>
+	public static class MailMessageExtensions
+	{
+		/// <summary>
+		/// Adds a tag to the <see cref="System.Net.Mail.MailMessage" />.
+		/// </summary>
+		/// <param name="mailMessage">The <see cref="System.Net.Mail.MailMessage" /> instance.</param>
+		/// <param name="tag">The tag to add to the <see cref="System.Net.Mail.MailMessage" />.</param>
+		public static void AddTag(this MailMessage mailMessage, string tag)
+		{
+			mailMessage.Headers.Add("X-Mailgun-Tag", tag);
+		}
+	}
+}

--- a/src/Typesafe.Mailgun/FormPartsBuilder.cs
+++ b/src/Typesafe.Mailgun/FormPartsBuilder.cs
@@ -47,6 +47,21 @@ namespace Typesafe.Mailgun
 
             		result.AddRange(message.GetBodyParts());
 
+			// Check for the existense of any Mailgun Tag headers
+			if (message.Headers.AllKeys.Contains("X-Mailgun-Tag"))
+			{
+				// Grab the Mailgun tag header values
+				var tagHeaders = message.Headers.GetValues("X-Mailgun-Tag");
+				if (tagHeaders != null)
+				{
+					// Iterate over the collection and add each tag header to the result
+					foreach (var tag in tagHeaders)
+					{
+						result.Add(new SimpleFormPart("o:tag", tag));
+					}
+				}
+			}
+
 			result.AddRange(message.Attachments.Select(attachment => new AttachmentFormPart(attachment)));
 
 			return result;

--- a/src/Typesafe.Mailgun/Typesafe.Mailgun.csproj
+++ b/src/Typesafe.Mailgun/Typesafe.Mailgun.csproj
@@ -46,6 +46,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DeleteCommand.cs" />
+    <Compile Include="Extensions\MailMessageExtensions.cs" />
     <Compile Include="FormPartsBuilder.cs" />
     <Compile Include="Http\MailgunHttpResponse.cs" />
     <Compile Include="IMailgunClient.cs" />


### PR DESCRIPTION
As a user moving from SendGrid to Mailgun I was missing the ability to tag email messages for report filtering. This PR addresses this missing feature.
