### PR TITLE
Update nuget.config to newer format

### DIFF
--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<settings>
-	<repositoryPath>../packages</repositoryPath>
-</settings>
+<configuration>
+	<config>		
+		<add key="repositoryPath" value="../packages" />		
+	</config>
+</configuration>


### PR DESCRIPTION
The nuget.config was not compatible with VS2015. This version should be backwards compatible with older VS/nuget versions.