### PR TITLE
Add References and InResponseTo Headers

### DIFF
--- a/src/Typesafe.Mailgun/FormPartsBuilder.cs
+++ b/src/Typesafe.Mailgun/FormPartsBuilder.cs
@@ -78,6 +78,26 @@ namespace Typesafe.Mailgun
 					}
 				}
 			}
+			
+			if (message.Headers.AllKeys.Contains("References"))
+			{
+				// Grab the References Header
+				var References = message.Headers.GetValues("References");
+				if (References != null)
+				{
+					result.Add(new SimpleFormPart("h:References", References));
+				}
+			}
+			
+			if (message.Headers.AllKeys.Contains("In-Reply-To"))
+			{
+				// Grab the References Header
+				var inReplyTo = message.Headers.GetValues("In-Reply-To");
+				if (inReplyTo != null)
+				{
+					result.Add(new SimpleFormPart("h:In-Reply-To", inReplyTo));
+				}
+			}
 
 			result.AddRange(message.Attachments.Select(attachment => new AttachmentFormPart(attachment)));
 

--- a/src/Typesafe.Mailgun/FormPartsBuilder.cs
+++ b/src/Typesafe.Mailgun/FormPartsBuilder.cs
@@ -82,7 +82,7 @@ namespace Typesafe.Mailgun
 			if (message.Headers.AllKeys.Contains("References"))
 			{
 				// Grab the References Header
-				var References = message.Headers.GetValues("References");
+				var References = message.Headers["References"];
 				if (References != null)
 				{
 					result.Add(new SimpleFormPart("h:References", References));
@@ -92,7 +92,7 @@ namespace Typesafe.Mailgun
 			if (message.Headers.AllKeys.Contains("In-Reply-To"))
 			{
 				// Grab the References Header
-				var inReplyTo = message.Headers.GetValues("In-Reply-To");
+				var inReplyTo = message.Headers["In-Reply-To"];
 				if (inReplyTo != null)
 				{
 					result.Add(new SimpleFormPart("h:In-Reply-To", inReplyTo));


### PR DESCRIPTION
Add Headers for References and InResponseTo
They were previously ignored, which prevented Office 365 correctly Threading return messages sent.

Adding Headers should be done too... But I just need these 2 headers for now.
https://documentation.mailgun.com/en/latest/api-sending.html#sending
Check the headers prefix documentation.
_____________________________________________________
Ryan Tregea
<a href="https://biztactix.com.au">Biztactix</a>