### PR TITLE
Add support for inline attachments

### DIFF
--- a/src/Typesafe.Mailgun/FormPartsBuilder.cs
+++ b/src/Typesafe.Mailgun/FormPartsBuilder.cs
@@ -82,6 +82,7 @@ namespace Typesafe.Mailgun
 			}
 
 			result.AddRange(message.Attachments.Select(attachment => new AttachmentFormPart(attachment)));
+			result.AddRange(message.GetAlternatePartResources(MediaTypeNames.Text.Html));
 
 			return result;
 		}
@@ -118,6 +119,21 @@ namespace Typesafe.Mailgun
 			}
 
 			return null;
+		}
+
+		private static List<AttachmentFormPart> GetAlternatePartResources(this MailMessage message, string contentType)
+		{
+			var result = new List<AttachmentFormPart>();
+
+			var alt = message.AlternateViews.FirstOrDefault(v => v.ContentType.MediaType == contentType);
+
+			if (alt != null)
+			{
+				result.AddRange(alt.LinkedResources.Select(attachment => new AttachmentFormPart(attachment)));
+				return result;
+			}
+
+			return result;
 		}
 	}
 }

--- a/src/Typesafe.Mailgun/Http/AttachmentFormPart.cs
+++ b/src/Typesafe.Mailgun/Http/AttachmentFormPart.cs
@@ -9,19 +9,30 @@ namespace Typesafe.Mailgun.Http
 	/// </summary>
 	public class AttachmentFormPart : FormPart
 	{
-		public AttachmentFormPart(Attachment attachment)
+		public AttachmentFormPart(AttachmentBase attachment)
 		{
 			Attachment = attachment;
 		}
 
-		public Attachment Attachment { get; }
+		public AttachmentBase Attachment { get; }
 
 		public override void WriteTo(StreamWriter writer, string boundary)
 		{
-			writer.Write("--{0}\r\nContent-Disposition: form-data; name=\"attachment\"; filename=\"{1}\"\r\nContent-Type: {2}\r\nContent-Transfer-Encoding: base64\r\n\r\n",
-				boundary,
-				Attachment.Name,
-				Attachment.ContentType.MediaType);
+			if (Attachment is Attachment regularAttachment)
+			{
+				writer.Write("--{0}\r\nContent-Disposition: form-data; name=\"attachment\"; filename=\"{1}\"\r\nContent-Type: {2}\r\nContent-Transfer-Encoding: base64\r\n\r\n",
+					boundary,
+					regularAttachment.Name,
+					regularAttachment.ContentType.MediaType);
+			}
+
+			if (Attachment is LinkedResource linkedResource)
+			{
+				writer.Write("--{0}\r\nContent-Disposition: form-data; name=\"inline\"; filename=\"{1}\"\r\nContent-Type: {2}\r\nContent-Transfer-Encoding: base64\r\n\r\n",
+					boundary,
+					linkedResource.ContentId,
+					linkedResource.ContentType.MediaType);
+			}
 
 			var bytes = new byte[Attachment.ContentStream.Length];
 			Attachment.ContentStream.Read(bytes, 0, (int) Attachment.ContentStream.Length);


### PR DESCRIPTION
If you add an "inline" attachment (such as an image), the current implementation will not include the file and this will show as a broken image in the email.

This change adds support for inline attachments.