### PR TITLE
Add support for sending in test mode

### DIFF
--- a/src/Typesafe.Mailgun/FormPartsBuilder.cs
+++ b/src/Typesafe.Mailgun/FormPartsBuilder.cs
@@ -81,6 +81,15 @@ namespace Typesafe.Mailgun
 				}
 			}
 
+			if (message.Headers.AllKeys.Contains("X-Mailgun-Drop-Message"))
+			{
+				var dropMessage = message.Headers.GetValues("X-Mailgun-Drop-Message")?.FirstOrDefault();
+				if (dropMessage == "yes")
+				{
+					result.Add(new SimpleFormPart("o:testmode", "yes"));
+				}
+			}
+
 			result.AddRange(message.Attachments.Select(attachment => new AttachmentFormPart(attachment)));
 
 			return result;


### PR DESCRIPTION
Enables sending in test mode.

You can send messages in test mode by setting o:testmode parameter to true. When you do this, Mailgun will accept the message but will not send it. This is useful for testing purposes.