### PR TITLE
Add support for sending in native mode

### DIFF
--- a/src/Typesafe.Mailgun/FormPartsBuilder.cs
+++ b/src/Typesafe.Mailgun/FormPartsBuilder.cs
@@ -81,6 +81,15 @@ namespace Typesafe.Mailgun
 				}
 			}
 
+			if (message.Headers.AllKeys.Contains("X-Mailgun-Native-Send"))
+			{
+				var nativeSend = message.Headers.GetValues("X-Mailgun-Native-Send")?.FirstOrDefault();
+				if (nativeSend == "yes")
+				{
+					result.Add(new SimpleFormPart("o:native-send", "yes"));
+				}
+			}
+
 			result.AddRange(message.Attachments.Select(attachment => new AttachmentFormPart(attachment)));
 
 			return result;


### PR DESCRIPTION
Add support for setting the native send header.

Adding "x-mailgun-native-send: true" to the header of your message to turn off sender address rewriting. See https://help.mailgun.com/hc/en-us/articles/360011804533-Sender-Verification-Error for more information