### PR TITLE
Added option to choose Mailgun's EU API

### DIFF
--- a/src/Typesafe.Mailgun.Tests/MailgunClientBuilder.cs
+++ b/src/Typesafe.Mailgun.Tests/MailgunClientBuilder.cs
@@ -3,9 +3,15 @@
 	public static class MailgunClientBuilder
 	{
 		// TODO: put your domain and API key here before running tests
-		public static MailgunClient GetClient(string domain = "yourdomain")
+		private const string YourDomain = "your.domain";
+
+		private const bool IsEuDomain = false;
+
+		private const string YourApiKey = "your-api-key";
+
+		public static MailgunClient GetClient(string domain = YourDomain, bool euDomain = IsEuDomain)
 		{
-			return new MailgunClient(domain, "key-withyourapikey", 3);
+			return new MailgunClient(domain, YourApiKey, 3, euDomain);
 		}
 	}
 }

--- a/src/Typesafe.Mailgun.Tests/When_sending_an_email_message_for_a_standard_domain.cs
+++ b/src/Typesafe.Mailgun.Tests/When_sending_an_email_message_for_a_standard_domain.cs
@@ -1,0 +1,18 @@
+using Xunit;
+
+namespace Typesafe.Mailgun.Tests
+{
+	[Trait("Category", TestCategory.Integration)]
+	public class When_sending_an_email_message_for_a_standard_domain
+	{
+		[Fact]
+		public void the_standard_api_url_should_be_used()
+		{
+			var client = MailgunClientBuilder.GetClient("foobar.com", false);
+
+			const string apiUrl = "https://api.mailgun.net";
+
+			Assert.StartsWith(apiUrl, client.DomainBaseUrl.ToString());
+		}
+	}
+}

--- a/src/Typesafe.Mailgun.Tests/When_sending_an_email_message_for_an_eu_domain.cs
+++ b/src/Typesafe.Mailgun.Tests/When_sending_an_email_message_for_an_eu_domain.cs
@@ -1,0 +1,18 @@
+using Xunit;
+
+namespace Typesafe.Mailgun.Tests
+{
+	[Trait("Category", TestCategory.Integration)]
+	public class When_sending_an_email_message_for_an_eu_domain
+	{
+		[Fact]
+		public void the_eu_api_url_should_be_used()
+		{
+			var client = MailgunClientBuilder.GetClient("foobar.com", true);
+
+			const string euApiUrl = "https://api.eu.mailgun.net";
+
+			Assert.StartsWith(euApiUrl, client.DomainBaseUrl.ToString());
+		}
+	}
+}

--- a/src/Typesafe.Mailgun/MailgunClient.cs
+++ b/src/Typesafe.Mailgun/MailgunClient.cs
@@ -14,9 +14,16 @@ namespace Typesafe.Mailgun
 		/// <summary>
 		/// Initializes a new client for the specified domain and api key.
 		/// </summary>
-		public MailgunClient(string domain, string apiKey, int version)
+		public MailgunClient(string domain, string apiKey, int version, bool euDomain = false)
 		{
-			DomainBaseUrl = new Uri(string.Format("https://api.mailgun.net/v{0}/", version) + domain + "/");
+			var apiUrl = "https://api.mailgun.net";
+
+			if (euDomain)
+			{
+				apiUrl = "https://api.eu.mailgun.net";
+			}
+
+			DomainBaseUrl = new Uri($"{apiUrl}/v{version}/{domain}/");
 			ApiKey = apiKey;
 		}
 


### PR DESCRIPTION
Mailgun's standard API has the url https://api.mailgun.net

However, to send e-mail from a EU domain, you need to use the url https://api.eu.mailgun.net

Added optionial setting to MailgunClient constructur: bool euDomain